### PR TITLE
Add simple IDP wiremock

### DIFF
--- a/libraries/ocb-test-engine/pom.xml
+++ b/libraries/ocb-test-engine/pom.xml
@@ -59,6 +59,11 @@
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>dk.dbc</groupId>
+            <artifactId>idp-connector</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.perf4j</groupId>
             <artifactId>perf4j</artifactId>
             <version>${maven.perf4j.plugin.version}</version>


### PR DESCRIPTION
Currently, there are no tests which checks for failed validation, so for now only a simple "ok" wiremock is implemented.